### PR TITLE
Runs bower install before starting web server

### DIFF
--- a/bin/polyserve
+++ b/bin/polyserve
@@ -16,5 +16,7 @@ process.title = 'polyserve';
 
 resolve('polyserve', {basedir: process.cwd()}, function(error, path) {
   var polyserve = path ? require(path) : require('..');
-  polyserve.startServer(argv.p);
+  polyserve.bowerInstall(function() {
+    polyserve.startServer(argv.p);
+  });
 });

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@
  */
 
 module.exports = {
+  bowerInstall: require('./src/bower').install,
   startServer: require('./src/start_server'),
   makeApp: require('./src/make_app')
 };

--- a/src/bower.js
+++ b/src/bower.js
@@ -10,6 +10,7 @@
 
 var path = require('path');
 var fs = require('fs');
+var spawn = require('child_process').spawn;
 
 function bowerConfigPath() {
   return path.resolve(process.cwd(), 'bower.json');
@@ -28,7 +29,7 @@ function bowerConfigContents() {
   return contents || '{}';
 }
 
-function bowerConfig() {
+function config() {
   try {
     return JSON.parse(bowerConfigContents());
   } catch (e) {
@@ -39,4 +40,12 @@ function bowerConfig() {
   return {};
 }
 
-module.exports = bowerConfig;
+function install(cb) {
+  var proc = spawn('bower', ['install'], {stdio: 'inherit'});
+  proc.on('close', cb);
+}
+
+module.exports = {
+  config: config,
+  install: install
+};

--- a/src/make_app.js
+++ b/src/make_app.js
@@ -13,7 +13,7 @@ var fs = require('fs');
 var path = require('path');
 var parseUrl = require('url').parse;
 var send = require('send');
-var bowerConfig = require('./bower_config');
+var bowerConfig = require('./bower').config;
 
 /**
  * Make a polyserve express app.


### PR DESCRIPTION
Since the presence of a `bower_components` directory is required, and since the contents of your `bower.json` tends to change during development, running a fresh `bower install` before starting up the server seems prudent.

It's a no-op that exits quickly if nothing in your `bower.json` has changed.