### PR TITLE
Adds an -o option to open your default browser to an initial page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Navigate to `localhost:8080/components/my-element/demo.html`
 ### Options
 
   * `-p` The TCP port to use for the web server
+  * `-o` Opens your default browser to an initial page, e.g. "demo" or "index.html"

--- a/bin/polyserve
+++ b/bin/polyserve
@@ -16,5 +16,5 @@ process.title = 'polyserve';
 
 resolve('polyserve', {basedir: process.cwd()}, function(error, path) {
   var polyserve = path ? require(path) : require('..');
-  polyserve.startServer(argv.p);
+  polyserve.startServer(argv.p, argv.o);
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "express": "^4.8.5",
     "minimist": "^1.1.1",
+    "open": "0.0.5",
     "resolve": "^1.0.0",
     "send": "^0.10.1"
   }

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -11,8 +11,10 @@
 var express = require('express');
 var http = require('http');
 var makeApp = require('./make_app');
+var open = require('open');
+var util = require('util');
 
-function startServer(port, componentDir, packageName) {
+function startServer(port, openPage, componentDir, packageName) {
   port = port || 8080;
   console.log('Starting Polyserve on port ' + port);
 
@@ -21,11 +23,15 @@ function startServer(port, componentDir, packageName) {
 
   app.use('/components/', polyserve);
 
-  console.log('Files in this directory are available at localhost:' +
-      port + '/components/' + polyserve.packageName + '/...');
-
   var server = http.createServer(app);
   server = app.listen(port);
+
+  var baseUrl = util.format('http://localhost:%d/components/%s/', port, polyserve.packageName);
+  console.log('Files in this directory are available under ' + baseUrl);
+
+  if (openPage) {
+    open(baseUrl + openPage);
+  }
 }
 
 module.exports = startServer;


### PR DESCRIPTION
I find myself wanting to do open up the demo pages immediately after starting the server, so `-o demo` will automate that.