### PR TITLE
add -h, -b options, fix -o

### DIFF
--- a/bin/polyserve
+++ b/bin/polyserve
@@ -14,7 +14,22 @@ var argv = require('minimist')(process.argv);
 
 process.title = 'polyserve';
 
+if (argv.h || argv.help) {
+  console.log("polyserve: web server for bower components\n\n" +
+    "Options:\n" +
+    "  -p <port>        defaults to 8080\n" +
+    "  -o <filename>    open page in default browser on startup (default: index.html)\n" +
+    "  -b <browsername> use this browser instead of default \n" +
+    "                   (ex: 'Google Chrome Canary')\n"
+  );
+  process.exit(0);
+}
+
 resolve('polyserve', {basedir: process.cwd()}, function(error, path) {
   var polyserve = path ? require(path) : require('..');
-  polyserve.startServer(argv.p, argv.o);
+  polyserve.startServer({
+    port: argv.p,
+    page: argv.o,
+    browser: argv.b
+  });
 });

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "polyserve",
   "version": "0.4.0",
   "description": "A simple dev server for bower components",
-  "license": {
-    "type": "BSD-3-Clause",
-    "url": "http://polymer.github.io/LICENSE.txt"
-  },
+  "license": "BSD-3-Clause",
   "repository": "PolymerLabs/polyserve",
   "main": "main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "express": "^4.8.5",
+    "find-port": "^1.0.1",
     "minimist": "^1.1.1",
     "open": "0.0.5",
     "resolve": "^1.0.0",

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -13,24 +13,50 @@ var http = require('http');
 var makeApp = require('./make_app');
 var open = require('open');
 var util = require('util');
+var findPort = require('find-port');
 
-function startServer(port, openPage, componentDir, packageName) {
-  port = port || 8080;
-  console.log('Starting Polyserve on port ' + port);
+function startWithPort(options) {
+
+  options.port = options.port || 8080;
+
+  console.log('Starting Polyserve on port ' + options.port);
 
   var app = express();
-  var polyserve = makeApp(componentDir, packageName);
+  var polyserve = makeApp(options.componentDir, options.packageName);
 
   app.use('/components/', polyserve);
 
   var server = http.createServer(app);
-  server = app.listen(port);
 
-  var baseUrl = util.format('http://localhost:%d/components/%s/', port, polyserve.packageName);
+  server = app.listen(options.port);
+
+  server.on('error', function(err) {
+    if (err.code === 'EADDRINUSE')
+      console.error("ERROR: Port in use", options.port, "Aborting!");
+    process.exit(69);
+  });
+
+  var baseUrl = util.format('http://localhost:%d/components/%s/', options.port,
+    polyserve.packageName);
   console.log('Files in this directory are available under ' + baseUrl);
 
-  if (openPage) {
-    open(baseUrl + openPage);
+  if (options.page) {
+    open(
+      baseUrl + (options.page === true ? 'index.html' : options.page),
+      options.browser
+    );
+  }
+}
+
+function startServer(options) {
+  if (!options.port) {
+    findPort(8080, 8180, function(ports) {
+      options.port = ports[0];
+      startWithPort(options);
+    });
+  }
+  else {
+    startWithPort(options);
   }
 }
 

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -15,6 +15,24 @@ var open = require('open');
 var util = require('util');
 var findPort = require('find-port');
 
+function startServer(options) {
+  if (!options.port) {
+    findPort(8080, 8180, function(ports) {
+      options.port = ports[0];
+      startWithPort(options);
+    });
+  }
+  else {
+    startWithPort(options);
+  }
+}
+
+/**
+ * @param {Object} options
+ * @param {Number} options.port -- port number
+ * @param {String=} options.page -- page path, ex: "/", "/index.html"
+ * @param {(String|String[])} options.browser -- names of browser apps to launch
+ */
 function startWithPort(options) {
 
   options.port = options.port || 8080;
@@ -32,7 +50,8 @@ function startWithPort(options) {
 
   server.on('error', function(err) {
     if (err.code === 'EADDRINUSE')
-      console.error("ERROR: Port in use", options.port, "\nPlease choose another port, or let an unused port be chosen automatically.");
+      console.error("ERROR: Port in use", options.port,
+        "\nPlease choose another port, or let an unused port be chosen automatically.");
     process.exit(69);
   });
 
@@ -43,24 +62,12 @@ function startWithPort(options) {
   if (options.page) {
     var url = baseUrl + (options.page === true ? 'index.html' : options.page);
     if (Array.isArray(options.browser)) {
-      for (var i=0; i<options.browser.length; i++)
+      for (var i = 0; i < options.browser.length; i++)
         open(url, options.browser[i]);
     }
     else {
       open(url, options.browser);
     }
-  }
-}
-
-function startServer(options) {
-  if (!options.port) {
-    findPort(8080, 8180, function(ports) {
-      options.port = ports[0];
-      startWithPort(options);
-    });
-  }
-  else {
-    startWithPort(options);
   }
 }
 

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -41,10 +41,14 @@ function startWithPort(options) {
   console.log('Files in this directory are available under ' + baseUrl);
 
   if (options.page) {
-    open(
-      baseUrl + (options.page === true ? 'index.html' : options.page),
-      options.browser
-    );
+    var url = baseUrl + (options.page === true ? 'index.html' : options.page);
+    if (Array.isArray(options.browser)) {
+      for (var i=0; i<options.browser.length; i++)
+        open(url, options.browser[i]);
+    }
+    else {
+      open(url, options.browser);
+    }
   }
 }
 

--- a/src/start_server.js
+++ b/src/start_server.js
@@ -32,7 +32,7 @@ function startWithPort(options) {
 
   server.on('error', function(err) {
     if (err.code === 'EADDRINUSE')
-      console.error("ERROR: Port in use", options.port, "Aborting!");
+      console.error("ERROR: Port in use", options.port, "\nPlease choose another port, or let an unused port be chosen automatically.");
     process.exit(69);
   });
 


### PR DESCRIPTION
Added some options to make it more useful:

-h for help
-b for picking browser other than default
-o now defaults to index.html, it used to open "true".
-p if unspecified, now scans ports for free port starting at 8080

This makes my workflow a lot simpler, lots of polyserves everywhere....
