### PR TITLE
Fixes #41: Issue 302s to redirect instead of 301s.

### DIFF
--- a/src/make_app.js
+++ b/src/make_app.js
@@ -38,7 +38,7 @@ function makeApp(options) {
   let app = express();
 
   app.get('/', function (req, res) {
-    res.redirect(301, `./${packageName}/`);
+    res.redirect(`./${packageName}/`);
   });
 
   app.get('*', function (req, res) {


### PR DESCRIPTION
Issuing 302s on localhost can lead to some browsers like Chrome
incorrectly issuing redirects when another app is run on the same port
at a different time. Using 302s to redirect will prevent this.