### PR TITLE
Options parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^2.2.0",
+    "sinon": "^1.17.4",
     "supertest": "^1.2.0",
     "typescript": "^1.8.10",
     "typings": "^0.8.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import {ArgDescriptor} from 'command-line-args';
 import * as path from 'path';
 import * as fs from 'fs';
 import {args} from './args';
-import {startServer, ServerOptions} from './start_server';
+import {startServerWithCliArgs, ServerOptions} from './start_server';
 
 export function run(): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -32,17 +32,6 @@ export function run(): Promise<void> {
       return;
     }
 
-    var options: ServerOptions = {
-      root: cliOptions.root,
-      port: cliOptions.port,
-      hostname: cliOptions.hostname,
-      open: cliOptions.open,
-      browser: cliOptions['browser'],
-      openPath: cliOptions['open-path'],
-      componentDir: cliOptions['component-dir'],
-      packageName: cliOptions['package-name'],
-    }
-
     if (cliOptions.help) {
       printUsage(cli);
       resolve(null);
@@ -50,7 +39,7 @@ export function run(): Promise<void> {
       console.log(getVersion());
       resolve(null);
     } else {
-      return startServer(options);
+      return startServerWithCliArgs(cliOptions);
     }
   });
 }

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -53,6 +53,7 @@ function applyDefaultOptions(options: ServerOptions): ServerOptions {
     port: options.port || 8080,
     hostname: options.hostname || "localhost",
     root: path.resolve(options.root || '.'),
+    openPath: options.openPath || "index.html",
   });
   return withDefaults;
 }

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -80,6 +80,26 @@ ERROR: Port in use: ${port}
 Please choose another port, or let an unused port be chosen automatically.
 `;
 
+/**
+ * Like startServer(), but takes CLI "hyphen-seperated" formatted arguments and
+ * parses them into the desired "lowerCamelCase" formatted ServerOption properties.
+ */
+export function startServerWithCliArgs(options: any): Promise<http.Server> {
+  var parsedOptions: ServerOptions = {
+    root: options.root,
+    port: options.port,
+    hostname: options.hostname,
+    open: options.open,
+    openBrowser: options['open-browser'],
+    openPath: options['open-path'],
+    componentDir: options['component-dir'],
+    packageName: options['package-name'],
+  }
+
+  console.log(startServer);
+  return exports.startServer(parsedOptions);
+}
+
 export function getApp(options: ServerOptions) {
   let port = options.port;
   let hostname = options.hostname;


### PR DESCRIPTION
(Relies on #81, which has been pulled into the PR because github is bad)

This will allow polytool to better consume polyserve without having to duplicate the CLI argument mapping logic.

CR @justinfagnani 
