### PR TITLE
Allow dotfiles request

### DIFF
--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -67,7 +67,7 @@ export function makeApp(options: AppOptions): PolyserveApplication {
         (<any>res).append(header, headers[header]);
       }
     }
-    send(req, filePath).pipe(res);
+    send(req, filePath, {dotfiles: 'allow'}).pipe(res);
   });
   app.packageName = packageName;
   return app;


### PR DESCRIPTION
I need to request dotfiles from my app. Would you consider using the allow option? is there a reason not to?
