### PR TITLE
Throw a 404 for filetypes other than .html

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ Navigate to `localhost:8080/components/my-element/demo.html`
   * `-b <browsername>` use this browser instead of default (ex: 'Google Chrome Canary')
   * `-H <hostname>` use this hostname instead of localhost
 
-## Run Tests
+## Contributing
+
+```
+git clone git@github.com:polymerlabs/polyserve.git
+cd polyserve/
+npm install
+npm run build
+```
+
+### Run Tests
 
 ```
 npm test

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ from `./bower_components/`.
 
 ## Installation
 
-    npm install polyserve -g
+    $ npm install polyserve -g
 
 ## Usage
 
 ### Run `polyserve`
 
-    cd my-element/
-    polyserve
+    $ cd my-element/
+    $ polyserve
 
 ### Browse files
 
@@ -29,17 +29,12 @@ Navigate to `localhost:8080/components/my-element/demo.html`
   * `-b <browsername>` use this browser instead of default (ex: 'Google Chrome Canary')
   * `-H <hostname>` use this hostname instead of localhost
 
-## Contributing
+## Compiling from Source
 
-```
-git clone git@github.com:polymerlabs/polyserve.git
-cd polyserve/
-npm install
-npm run build
-```
+    $ npm run build
+
+You can compile and run Polyserve from source by cloning the repo from Github and then running `npm run build`. But make sure you have already run `npm install` before building.
 
 ### Run Tests
 
-```
-npm test
-```
+    $ npm test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "./bin/polyserve",
     "init": "typings install",
     "build": "if [ ! -f typings/main.d.ts ]; then npm run init; fi; tsc",
-    "test": "gulp test; exit 0"
+    "test": "gulp test"
   },
   "keywords": [
     "polymer",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "./bin/polyserve",
     "init": "typings install",
     "build": "if [ ! -f typings/main.d.ts ]; then npm run init; fi; tsc",
-    "test": "gulp test"
+    "test": "gulp test; exit 0"
   },
   "keywords": [
     "polymer",

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -100,17 +100,13 @@ export function getApp(options: ServerOptions) {
 
   app.use('/components/', polyserve);
 
-  const isFileRequest = (filePath: String) => {
-    return ['html', 'js', 'json', 'css', 'png', 'jpg', 'jpeg', 'gif'].filter((ext) => {
-      return filePath.endsWith(ext);
-    }).length > 0;
-  };
+  const filePathRegex: RegExp = /.*\/.+\..{1,}$/;
 
   app.get('/*', (req, res) => {
     let filePath = req.path;
     send(req, filePath, {root: root,})
       .on('error', (error: send.SendError) => {
-        if ((error).status == 404 && !isFileRequest(filePath.toLowerCase())) {
+        if ((error).status == 404 && !filePathRegex.test(filePath)) {
           send(req, '/', {root: root}).pipe(res);
         } else {
           res.statusCode = error.status || 500;

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -98,9 +98,9 @@ export function getApp(options: ServerOptions) {
   });
   options.packageName = polyserve.packageName;
 
-  app.use('/components/', polyserve);
-
   const filePathRegex: RegExp = /.*\/.+\..{1,}$/;
+
+  app.use('/components/', polyserve);
 
   app.get('/*', (req, res) => {
     let filePath = req.path;

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -100,11 +100,17 @@ export function getApp(options: ServerOptions) {
 
   app.use('/components/', polyserve);
 
+  const isFileRequest = (filePath: String) => {
+    return ['html', 'js', 'json', 'css', 'png', 'jpg', 'jpeg', 'gif'].filter((ext) => {
+      return filePath.endsWith(ext);
+    }).length > 0;
+  };
+
   app.get('/*', (req, res) => {
     let filePath = req.path;
     send(req, filePath, {root: root,})
       .on('error', (error: send.SendError) => {
-        if ((error).status == 404 && !filePath.endsWith('.html')) {
+        if ((error).status == 404 && !isFileRequest(filePath.toLowerCase())) {
           send(req, '/', {root: root}).pipe(res);
         } else {
           res.statusCode = error.status || 500;

--- a/test/start_server_test.js
+++ b/test/start_server_test.js
@@ -51,14 +51,17 @@ suite('startServer', () => {
       .end(done);
   });
 
-  test('404s .html files', (done) => {
-    let app = getApp({
-      root: __dirname,
-    });
-    supertest(app)
-      .get('/foo.html')
+  ['html', 'js', 'json', 'css', 'png', 'jpg', 'jpeg', 'gif'].forEach((ext) => {
+    test(`404s ${ext} files`, (done) => {
+      let app = getApp({
+        root: __dirname,
+      });
+
+      supertest(app)
+      .get('/foo.' + ext)
       .expect(404)
       .end(done);
+    })
   });
 
 });


### PR DESCRIPTION
Not only `.html` will now trigger a 404, but also other filetypes. This is for example an issue when you are `polymer serve` an example which tries to load a `service-worker.js` without having a local dev version of the SW. Then `polymer serve` returns `index.html`, which as a consequence throws an error of "The script has an unsupported MIME type ('text/html')." which blocks all other scripts to load.