### PR TITLE
Check if bower.json exists to prevent incorrect console error

### DIFF
--- a/src/bower_config.ts
+++ b/src/bower_config.ts
@@ -13,11 +13,7 @@ import * as fs from 'fs';
 
 function bowerConfigPath(root?: string): string {
   root = root || process.cwd();
-  try {
-    return path.resolve(root, 'bower.json');
-  } catch (e) {
-    return null;
-  }
+  return path.resolve(root, 'bower.json');
 }
 
 function bowerConfigContents(root?: string): string {
@@ -33,11 +29,9 @@ function bowerConfigContents(root?: string): string {
 }
 
 export function bowerConfig(root?: string) {
+  const config = bowerConfigContents(root);
   try {
-    let config = bowerConfigContents(root);
-    if (config) {
-      return JSON.parse(config);
-    }
+    return JSON.parse(config);
   } catch (e) {
     console.error('Could not parse bower.json');
     console.error(e);

--- a/src/bower_config.ts
+++ b/src/bower_config.ts
@@ -13,7 +13,11 @@ import * as fs from 'fs';
 
 function bowerConfigPath(root?: string): string {
   root = root || process.cwd();
-  return path.resolve(root, 'bower.json');
+  try {
+    return path.resolve(root, 'bower.json');
+  } catch (e) {
+    return null;
+  }
 }
 
 function bowerConfigContents(root?: string): string {
@@ -22,8 +26,7 @@ function bowerConfigContents(root?: string): string {
   try {
     contents = fs.readFileSync(bowerConfigPath(root)).toString();
   } catch (e) {
-    console.error('Error reading config at ' + bowerConfigPath());
-    console.error(e);
+    return '{}'
   }
 
   return contents || '{}';
@@ -31,7 +34,10 @@ function bowerConfigContents(root?: string): string {
 
 export function bowerConfig(root?: string) {
   try {
-    return JSON.parse(bowerConfigContents(root));
+    let config = bowerConfigContents(root);
+    if (config) {
+      return JSON.parse(config);
+    }
   } catch (e) {
     console.error('Could not parse bower.json');
     console.error(e);

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -46,8 +46,8 @@ export function makeApp(options: AppOptions): PolyserveApplication {
     packageName = bowerConfig(root).name;
   }
   if (!packageName) {
-    console.log('bower.json not found, falling back to current path as package name');
-    packageName = path.basename(process.cwd());
+    packageName = path.basename(root || process.cwd());
+    console.log(`no bower.json detected, using name "${packageName}"`);
   }
   let headers = options.headers || {};
 

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -41,9 +41,15 @@ export function makeApp(options: AppOptions): PolyserveApplication {
   options = options || {};
   const root = options.root;
   const componentDir = options.componentDir || 'bower_components';
-  const packageName = options.packageName || bowerConfig(root).name
-      || path.basename(process.cwd());
-  const headers = options.headers || {};
+  let packageName = options.packageName;
+  if (!packageName){
+    packageName = bowerConfig(root).name;
+  }
+  if (!packageName) {
+    console.log('bower.json not found, falling back to current path as package name');
+    packageName = path.basename(process.cwd());
+  }
+  let headers = options.headers || {};
 
   const app: PolyserveApplication = <PolyserveApplication>express();
 

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -93,7 +93,7 @@ export function getApp(options: ServerOptions): express.Express {
   const polyserve = makeApp({
     componentDir: options.componentDir,
     packageName: options.packageName,
-    root,
+    root: root,
   });
   options.packageName = polyserve.packageName;
 

--- a/test/make_app_test.js
+++ b/test/make_app_test.js
@@ -34,7 +34,7 @@ suite('makeApp', () => {
       root: resolve(__dirname, 'no_bower_json/')
     });
     assert.isFalse(called);
-    assert.equal(app.packageName, 'polyserve');
+    assert.equal(app.packageName, 'no_bower_json');
   });
 
   test('serves package files', (done) => {

--- a/test/make_app_test.js
+++ b/test/make_app_test.js
@@ -1,10 +1,21 @@
 'use strict';
 
+const resolve = require('path').resolve;
 const makeApp = require('../lib/make_app').makeApp;
 const assert = require('chai').assert;
 const supertest = require('supertest');
 
 suite('makeApp', () => {
+
+  var consoleError;
+
+  setup(() => {
+    consoleError = console.error;
+  });
+
+  teardown(() => {
+    console.error = consoleError;
+  })
 
   test('returns an app', () => {
     let app = makeApp({
@@ -12,6 +23,18 @@ suite('makeApp', () => {
     });
     assert.isOk(app);
     assert.equal(app.packageName, 'polyserve-test');
+  });
+
+  test('shows friendly error when bower.json does not exist', () => {
+    let called = false;
+    console.error = function(e) {
+      called = true;
+    }
+    let app = makeApp({
+      root: resolve(__dirname, 'no_bower_json/')
+    });
+    assert.isFalse(called);
+    assert.equal(app.packageName, 'polyserve');
   });
 
   test('serves package files', (done) => {


### PR DESCRIPTION
Before calling `bowerConfig(root)`, check if the file actually exists.

Fixes https://github.com/Polymer/polymer-cli/issues/357
