### PR TITLE
Fix Argument of type 'ServerRequest' build error

### DIFF
--- a/custom_typings/send.d.ts
+++ b/custom_typings/send.d.ts
@@ -1,5 +1,5 @@
 declare module 'send' {
-  import {ServerRequest} from 'http';
+  import {IncomingMessage} from 'http';
   module send {
     interface SendError extends Error {
       status: number;
@@ -18,7 +18,7 @@ declare module 'send' {
   }
   // TODO(justinfagnani): any->Request
   function send(
-      req: ServerRequest,
+      req: IncomingMessage,
       path: string,
       options?: send.SendOptions): any;
   export = send;


### PR DESCRIPTION
$ npm run build

polyserve@0.13.0 build polyserve
tsc
src/make_app.ts(71,10): error TS2345: Argument of type 'Request' is not assignable to parameter of type 'ServerRequest'.
Property 'connection' is missing in type 'Request'.
src/start_server.ts(149,10): error TS2345: Argument of type 'Request' is not assignable to parameter of type 'ServerRequest'.
src/start_server.ts(152,16): error TS2345: Argument of type 'Request' is not assignable to parameter of type 'ServerRequest'.

npm ERR! Darwin 15.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "build"
npm ERR! node v5.9.1
npm ERR! npm v3.7.3
npm ERR! code ELIFECYCLE
npm ERR! polyserve@0.13.0 build: tsc
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the polyserve@0.13.0 build script 'tsc'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the polyserve package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR! tsc
npm ERR! You can get information on how to open an issue for this project with:
npm ERR! npm bugs polyserve
npm ERR! Or if that isn't available, you can get their info via:
npm ERR! npm owner ls polyserve
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR! polyserve/npm-debug.log