### PR TITLE
Reference custom typings so that they are properly exported

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -8,6 +8,8 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+/// <reference path="../custom_typings/command-line-args.d.ts" />
+
 import {ArgDescriptor} from 'command-line-args';
 
 export let args : ArgDescriptor[] = [

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -8,6 +8,8 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
+/// <reference path="../custom_typings/spdy.d.ts" />
+
 import * as assert from 'assert';
 import * as express from 'express';
 import * as mime from 'mime';


### PR DESCRIPTION
TS consumers are not currently able to compile their projects when polyserve is included.

/cc @rictic @justinfagnani 