### PR TITLE
Fix silent failure for `npm run build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "./bin/polyserve",
     "clean": "mkdir -p lib && rm -r lib",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && npm run tsc",
+    "tsc": "tsc",
     "test": "npm run build && mocha",
     "test:watch": "watchy -w src/ -- npm test",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated

The "build" npm script ran `npm run clean && tsc`, which runs the globally installed `tsc` rather than the local `tsc` in npm bin. When the global `tsc` is unavailable (not installed), the "build" script silently fails.

This patch adds a "tsc" npm script to run the locally installed `tsc`, and updates "build" to run that script. This makes the build independent of the host system.

### Test
 1. Globally uninstall `tsc`
```sh
npm uninstall -g typescript
```

 2. Run "build" npm script from `polyserve`'s root directory
```sh
npm run build
```

 3. Verify the `lib` directory contains newly generated files.

 4. Verify the console output contains something similar to:
```sh
$ npm run build

> polyserve@0.14.0 build /Users/tony/src/polymer/tony19-polyserve
> npm run clean && npm run tsc


> polyserve@0.14.0 clean /Users/tony/src/polymer/tony19-polyserve
> mkdir -p lib && rm -r lib


> polyserve@0.14.0 tsc /Users/tony/src/polymer/tony19-polyserve
> tsc
```
