### PR TITLE
add ability to serve user-provided routes before components/ handler

### DIFF
--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -48,7 +48,10 @@ export function makeApp(options: AppOptions): PolyserveApplication {
   // TODO(rictic): Doing option fallback here and in start_server is awkward. We
   // should have just one.
   const root = options.root;
-  const componentDir = options.componentDir || 'bower_components';
+  const baseComponentDir = options.componentDir || 'bower_components';
+  const componentDir = path.isAbsolute(baseComponentDir) ?
+      baseComponentDir :
+      path.join(root, baseComponentDir);
   let packageName = options.packageName;
   if (!packageName) {
     packageName = bowerConfig(root).name;
@@ -86,7 +89,6 @@ export function makeApp(options: AppOptions): PolyserveApplication {
         (<any>res).setHeader(header, headers[header]);
       }
     }
-
     const _send = send(req, filePath);
     // Uncomment this to disable 304s from send() and always compile. Useful
     // for working on the compilation middleware.

--- a/src/polyserve.ts
+++ b/src/polyserve.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+export {RequestHandler} from 'express';
 export {args} from './args';
 export {makeApp} from './make_app';
 export {ControlServer, MainlineServer, ServerInfo, ServerOptions, startServer, startServers, VariantServer} from './start_server';

--- a/src/polyserve.ts
+++ b/src/polyserve.ts
@@ -15,4 +15,4 @@
 export {RequestHandler} from 'express';
 export {args} from './args';
 export {makeApp} from './make_app';
-export {ControlServer, MainlineServer, ServerInfo, ServerOptions, startServer, startServers, VariantServer} from './start_server';
+export {ControlServer, MainlineServer, PolyserveServer, ServerInfo, ServerOptions, startServer, startServers, VariantServer} from './start_server';

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -76,6 +76,10 @@ export interface ServerOptions {
 
   /** Proxy to redirect for all matching `path` to `target` */
   proxy?: {path: string, target: string};
+
+  /** An optional list of routes & route handlers to attach to the polyserve
+   * app, to be handled before all others */
+  additionalRoutes?: Map<string, express.RequestHandler>;
 }
 
 async function applyDefaultOptions(options: ServerOptions):
@@ -287,6 +291,12 @@ export function getApp(options: ServerOptions): express.Express {
   const root = options.root || '.';
   const app = express();
 
+  if (options.additionalRoutes) {
+    options.additionalRoutes.forEach((handler, route) => {
+      app.get(route, handler);
+    });
+  }
+
   const polyserve = makeApp({
     componentDir: options.componentDir,
     packageName: options.packageName,
@@ -310,7 +320,8 @@ export function getApp(options: ServerOptions): express.Express {
 
     for (let char of ['*', '?', '+']) {
       if (escapedPath.indexOf(char) > -1) {
-        console.warn(`Proxy path includes character "${char}" which can cause problems during route matching.`);
+        console.warn(
+            `Proxy path includes character "${char}" which can cause problems during route matching.`);
       }
     }
 

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -44,6 +44,9 @@ export interface ServerOptions {
   /** The hostname to serve from */
   hostname?: string;
 
+  /** Headers to send with every response */
+  headers?: {[name: string]: string};
+
   /** Whether to open the browser when run **/
   open?: boolean;
 
@@ -289,6 +292,7 @@ export function getApp(options: ServerOptions): express.Express {
     packageName: options.packageName,
     root: root,
     compile: options.compile,
+    headers: options.headers,
   });
   options.packageName = polyserve.packageName;
 


### PR DESCRIPTION
This is a fork of @rictic's variant's branch which adds the ability for the user to define their own routes. This solves the problem where WCT needs to serve the generated webrunner out of the `components` directory, but polyserve handles all `components/` routes and returns a 404 because the file doesn't actually exist on disk. Because the response is handled, any later-attached route handlers never fire.

This was all we need to get wct running again. But I'd rather see this solved by having polyserve call next() inside it's route handler if the file was not found. This would give consumers the ability to attach routes to the `components/` directory to handle routes that polyserve can't. This would also solve the "generated test runner" problem.

/cc @rictic @justinfagnani 