### PR TITLE
Change default bind address from localhost to 0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 `--compile` flag controls compilation, with valid values of 'always', 'never',
 and 'auto'; and a default of 'auto'.
 * If the root dir contains directories that look like `bower_components-${foo}`, they will be treated as `dependency variants`. In that case, polyserve will start one server for each variant, enabling testing and development of your code against each set of dependencies.
+* `polymer serve` binds to '0.0.0.0' instead of localhost.
 
 ## [0.14.0] - 2016-11-17
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Navigate to `localhost:8080/components/my-element/demo.html`
   * `-p` The TCP port to use for the web server
   * `-o` Opens your default browser to an initial page, e.g. "demo" or "index.html"
   * `-b <browsername>` use this browser instead of default (ex: 'Google Chrome Canary')
-  * `-H <hostname>` use this hostname instead of localhost
+  * `-H <hostname>` use this hostname instead of 0.0.0.0 (all IP addresses) 
   * `-P <protocol>` The server protocol to use {`h2`, `https/1.1`, `http/1.1`}. **`h2` requires Node 5+.**
   * `-key <path>` Path to TLS certificate private key file for https. Defaults to "key.pem".
   * `-cert <path>` Path to TLS certificate file for https. Defaults to "cert.pem".

--- a/src/args.ts
+++ b/src/args.ts
@@ -46,7 +46,7 @@ export let args: ArgDescriptor[] = [
   {
     name: 'hostname',
     alias: 'H',
-    description: 'The hostname to serve from. Defaults to localhost',
+    description: 'The hostname to serve from. Defaults to 0.0.0.0 (all IP addresses)',
     type: String,
   },
   {

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -77,7 +77,7 @@ async function applyDefaultOptions(options: ServerOptions):
       const withDefaults = Object.assign({}, options);
       Object.assign(withDefaults, {
         port: await nextOpenPort(options.port),
-        hostname: options.hostname || 'localhost',
+        hostname: options.hostname || '0.0.0.0',
         root: path.resolve(options.root || '.'),
         certPath: options.certPath || 'cert.pem',
         keyPath: options.keyPath || 'key.pem',


### PR DESCRIPTION
 - [X] CHANGELOG.md has been updated

This is to work around an issue running `polymer serve` inside Docker containers, as explained in polymer/polymer-cli#300. It follows the same behavior as node's [http.Server.listen](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback).

With this change in place, `polymer serve` works inside a Docker container without having to use `-H 0.0.0.0`. 

One security drawback is that, in case a developer doesn't have a firewall in his/her laptop, this would expose the service. In my team's environment that would be okay (everybody has a firewall that defaults to block), but I'm not sure about others.