### PR TITLE
Extend command-line-args typing for cli

### DIFF
--- a/custom_typings/command-line-args.d.ts
+++ b/custom_typings/command-line-args.d.ts
@@ -12,8 +12,14 @@ declare module 'command-line-args' {
     }
   }
 
+  /**
+   * @param descriptors An array of objects that describe the arguments that
+   *     we want to parse.
+   * @param args Optional arguments to parse. If not given, process.argv is
+   *     used.
+   */
   function commandLineArgs(
-      groups: commandLineArgs.ArgDescriptor[], args?: string[]): any;
+      descriptors: commandLineArgs.ArgDescriptor[], args?: string[]): any;
 
   export = commandLineArgs;
 }

--- a/custom_typings/command-line-args.d.ts
+++ b/custom_typings/command-line-args.d.ts
@@ -1,6 +1,4 @@
 declare module 'command-line-args' {
-  function commandLineArgs(args: commandLineArgs.ArgDescriptor[]): any;
-
   module commandLineArgs {
     interface ArgDescriptor {
       name: string;
@@ -10,8 +8,12 @@ declare module 'command-line-args' {
       type?: Object;
       multiple?: boolean;
       defaultOption?: boolean;
+      group?: string;
     }
   }
+
+  function commandLineArgs(
+      groups: commandLineArgs.ArgDescriptor[], args?: string[]): any;
 
   export = commandLineArgs;
 }


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

With this we can delete the custom_typings from cli and there's no conflict. Will upstream all of this the moment the testing fire is out.