### PR TITLE
Added -u/--component-url feature.  (Also deduplicated logic for applying default server options.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Added `-u`/`--component-url` option to support expressing different url to
+  fetch components from than `components`.
+
 ### Fixed
 * When no port is given, do a better job of finding an available port.
  * Uses the list of [sauce-legal](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+FAQS#SauceConnectProxyFAQS-CanIAccessApplicationsonlocalhost?) ports.

--- a/src/args.ts
+++ b/src/args.ts
@@ -65,6 +65,13 @@ export let args: ArgDescriptor[] = [
     type: String,
   },
   {
+    name: 'component-url',
+    alias: 'u',
+    description: 'The component url to use. Defaults to reading from' +
+        ' the Bower config (usually bower_components/)',
+    type: String,
+  },
+  {
     name: 'package-name',
     alias: 'n',
     description: 'The package name to use for the root directory. Defaults to' +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,7 @@ export async function run(): Promise<StartServerResult> {
     browser: cliOptions['browser'],
     openPath: cliOptions['open-path'],
     componentDir: cliOptions['component-dir'],
+    componentUrl: cliOptions['component-url'],
     packageName: cliOptions['package-name'],
     protocol: cliOptions['protocol'],
     keyPath: cliOptions['key'],

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -22,7 +22,7 @@ import {babelCompile} from './compile-middleware';
 import send = require('send');
 
 export interface AppOptions {
-  componentDir?: string;
+  componentDir: string;
   packageName?: string;
   headers?: {[name: string]: string};
   root?: string;
@@ -44,11 +44,8 @@ export interface PolyserveApplication extends express.Express {
  * @return {Object} An express app which can be served with `app.get`
  */
 export function makeApp(options: AppOptions): PolyserveApplication {
-  options = options || {};
-  // TODO(rictic): Doing option fallback here and in start_server is awkward. We
-  // should have just one.
   const root = options.root;
-  const baseComponentDir = options.componentDir || 'bower_components';
+  const baseComponentDir = options.componentDir;
   const componentDir = path.isAbsolute(baseComponentDir) ?
       baseComponentDir :
       path.join(root, baseComponentDir);

--- a/src/test/make_app_test.ts
+++ b/src/test/make_app_test.ts
@@ -19,17 +19,18 @@ import * as supertest from 'supertest-as-promised';
 import {makeApp} from '../make_app';
 
 const root = path.join(__dirname, '..', '..', 'test');
+const componentDir = path.join(root, 'components');
 
 suite('makeApp', () => {
 
   test('returns an app', () => {
-    let app = makeApp({root});
+    let app = makeApp({root, componentDir});
     assert.isOk(app);
     assert.equal(app.packageName, 'polyserve-test');
   });
 
   test('serves package files', async() => {
-    let app = makeApp({root});
+    let app = makeApp({root, componentDir});
     await supertest(app)
         .get('/polyserve-test/test-file.txt')
         .expect(200, 'PASS\n');
@@ -50,7 +51,8 @@ suite('makeApp', () => {
     console.error = function(_e: any) {
       called = true;
     };
-    const app = makeApp({root: path.resolve(__dirname, 'no_bower_json/')});
+    const app = makeApp(
+        {root: path.resolve(__dirname, 'no_bower_json/'), componentDir});
     assert.isFalse(called);
     assert.equal(app.packageName, 'no_bower_json');
   });

--- a/src/test/start_server_test.ts
+++ b/src/test/start_server_test.ts
@@ -183,6 +183,7 @@ suite('startServer', () => {
         // reset paths to key/cert files so that default paths are used
         _serverOptions.keyPath = undefined;
         _serverOptions.certPath = undefined;
+        _serverOptions = _serverOptions;
 
         const certFilePath = 'cert.pem';
         const keyFilePath = 'key.pem';

--- a/src/test/start_server_test.ts
+++ b/src/test/start_server_test.ts
@@ -183,7 +183,6 @@ suite('startServer', () => {
         // reset paths to key/cert files so that default paths are used
         _serverOptions.keyPath = undefined;
         _serverOptions.certPath = undefined;
-        _serverOptions = _serverOptions;
 
         const certFilePath = 'cert.pem';
         const keyFilePath = 'key.pem';


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Added the `-u`/`--component-url` flag to allow you to specify something other than `components` as the URL to serve the components out of.  A partner option for `--component-dir` but they don't currently inform each other.

I think if we did a major release, polyserve should honor the `directory` flag of the root's `.bowerrc` and in the absense of that default `--component-dir` and `--component-url` to bower's default of `bower_components`  -- *at least* when a bower.json file is present, indicating polyserve is serving an app that uses bower.